### PR TITLE
Fixed read.pums() Function

### DIFF
--- a/HEMpopgen.R
+++ b/HEMpopgen.R
@@ -285,7 +285,7 @@ cumul.prob = function(x) {
 
 read.pums = function() {
   filename <- paste0(files$inpath,files$HEMpums)
-  if(!exists("pums")) pums <- fread(filename,colClasses = c(rep("character",5),rep("numeric",4),rep("character",2),"numeric"))
+  if(!exists("pums")) pums <- fread(filename,colClasses = c(rep("character",5),rep("numeric",4),rep("character",2)))
   pums[, `:=`(state, substr(compid,1,2))]
   x <- pums[pums$state %in% g$states]
   y <- x[x$age>=g$min.age & x$age<=g$max.age]


### PR DESCRIPTION
Removed extraneous 12th "numeric" data type from colClasses parameter for fread() within read.pums. The input hempums.csv only has 11 columns, which are accounted for by the other data types within the colClasses list.