### PR TITLE
Removed extraneous "source('HEMcontrol.R')" line

### DIFF
--- a/HEMcontrol.R
+++ b/HEMcontrol.R
@@ -38,7 +38,6 @@ HEM.setup = function(wd=NULL) {
   library("msm")
   library("truncnorm")
   library("survey")
-  source("HEMcontrol.R")
   source("HEMpopgen.R")
   source("httkpop2.R")
   source("HEMhousing.R")


### PR DESCRIPTION
Removed extraneous command which loads in the functions from HEMcontrol.R into the global environment. Since this was called within the HEM.setup() function found within HEMcontrol.R, this is redundant. The source('HEMcontrol.R') command should be ran before calling HEM.setup().